### PR TITLE
Add download history transaction api call

### DIFF
--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -302,7 +302,8 @@ module WxPay
       params = {
         appid: options.delete(:appid) || WxPay.appid,
         mch_id: options.delete(:mch_id) || WxPay.mch_id,
-        nonce_str: SecureRandom.uuid.tr('-', '')
+        nonce_str: SecureRandom.uuid.tr('-', ''),
+        bill_type: 'ALL' # Api document says this is optional but API response fails without it
       }.merge(params)
 
       check_required_options(params, DOWNLOAD_TRANSACTION_HISTORY)

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -308,6 +308,9 @@ module WxPay
 
       check_required_options(params, DOWNLOAD_TRANSACTION_HISTORY)
 
+      # Convert bill_date to appropriate format
+      params[:bill_date] = params[:bill_date].to_date.strftime('%Y%m%d')
+
       options = {
         ssl_client_cert: options.delete(:apiclient_cert) || WxPay.apiclient_cert,
         ssl_client_key: options.delete(:apiclient_key) || WxPay.apiclient_key,

--- a/lib/wx_pay/service.rb
+++ b/lib/wx_pay/service.rb
@@ -297,6 +297,29 @@ module WxPay
       r
     end
 
+    DOWNLOAD_TRANSACTION_HISTORY = [:bill_date]
+    def self.download_transaction_history(params, options = {})
+      params = {
+        appid: options.delete(:appid) || WxPay.appid,
+        mch_id: options.delete(:mch_id) || WxPay.mch_id,
+        nonce_str: SecureRandom.uuid.tr('-', '')
+      }.merge(params)
+
+      check_required_options(params, DOWNLOAD_TRANSACTION_HISTORY)
+
+      options = {
+        ssl_client_cert: options.delete(:apiclient_cert) || WxPay.apiclient_cert,
+        ssl_client_key: options.delete(:apiclient_key) || WxPay.apiclient_key,
+        verify_ssl: OpenSSL::SSL::VERIFY_NONE
+      }.merge(options)
+
+      r = WxPay::Result.new(Hash.from_xml(invoke_remote("/pay/downloadbill", make_payload(params), options)))
+
+      yield r if block_given?
+
+      r
+    end
+
     INVOKE_REVERSE_REQUIRED_FIELDS = [:out_trade_no]
     def self.invoke_reverse(params, options = {})
       params = {

--- a/lib/wx_pay/sign.rb
+++ b/lib/wx_pay/sign.rb
@@ -6,7 +6,7 @@ module WxPay
     SIGN_TYPE_MD5 = 'MD5'
     SIGN_TYPE_HMAC_SHA256 = 'HMAC-SHA256'
 
-    def self.generate(params, sign_type = SIGN_TYPE_MD5)
+    def self.generate(params, sign_type = SIGN_TYPE_HMAC_SHA256)
       key = params.delete(:key)
 
       new_key = params["key"] #after

--- a/test/wx_pay/service_test.rb
+++ b/test/wx_pay/service_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 
 class ServiceTest < MiniTest::Test
 

--- a/wx_pay.gemspec
+++ b/wx_pay.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", '~> 11.2'
   s.add_development_dependency "webmock", '~> 2.3'
   s.add_development_dependency "minitest", '~> 5'
+  s.add_development_dependency "pry", "~> 0.12.2"
 end


### PR DESCRIPTION
This can be used to download the transaction reports from Wechat.

I also changed the default encoding from md5 to sha256 just be sure.